### PR TITLE
some fixes to hypythetically make this platform agnostic. i.e. window…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on: [push]
+jobs:
+  run-unit-tests-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+      - run: python3 -m unittest -v test/test_pyconvcli.py
+  run-unit-tests-windows:
+    runs-on: windows-latest    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.1'
+      - run: python3 -m unittest -v test/test_pyconvcli.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9.1'
+      - run: python3 setup.py install
       - run: python3 -m unittest -v test/test_pyconvcli.py
   run-unit-tests-windows:
     runs-on: windows-latest    
@@ -15,4 +16,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9.1'
-      - run: python3 -m unittest -v test/test_pyconvcli.py
+      - run: python setup.py install
+      - run: python -m unittest -v test/test_pyconvcli.py

--- a/cli/new.py
+++ b/cli/new.py
@@ -70,7 +70,7 @@ class New_CLI():
                     setup_content=f'{setup_content}{variable}="{locals()[variable]}",\n        '
     
             print("created a setup.py file")
-            with open(f'{os.path.dirname(os.path.realpath(__file__))}/resources/setup_template.txt', 'r') as f:
+            with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),'resources','setup_template.txt'), 'r') as f:
                 setup_file=f.read().format(profile_info=setup_content.strip(' \t\n\r'), cli_entry_point=entry_point,project_name=name, entry_package=entry_package_name)
                 
                 f = open("setup.py", "w")

--- a/pyconvcli/pyconvcli.py
+++ b/pyconvcli/pyconvcli.py
@@ -42,7 +42,7 @@ class PyConvCli():
                     module_name = name.split('.py')[0]
                 
                     if not root == first_root:
-                        path_array = root[len(first_root)+1:len(root)].split('/')
+                        path_array = root[len(first_root)+1:len(root)].split(os.sep)
                         path_array.append(module_name)
                         module_name = '.'.join(path_array)
                     


### PR DESCRIPTION
the path structure may be different in Windows computers so anywhere we change a path we need to use the os.sep variable to ensure we split both / and \ based on the operating system.