### PR TITLE
added support for actions

### DIFF
--- a/pyconvcli/__init__.py
+++ b/pyconvcli/__init__.py
@@ -1,2 +1,2 @@
 from .pyconvcli import PyConvCli
-from .parse_classes import ParserArgType, ParserArgMutuallyExclusiveType,ParserArgGroupType,ArgGroupsDecorator
+from .parse_classes import ParserArgType, ParserArgMutuallyExclusiveType,ParserArgGroupType,ArgGroupsDecorator,ActionArguement

--- a/pyconvcli/parse_classes.py
+++ b/pyconvcli/parse_classes.py
@@ -1,6 +1,8 @@
 
 
-from pydash import get,omit
+from pydash import get,omit, pick, merge
+import argparse
+import inspect
 
 class ParserArgType():
     def __init__(self, *args, **kwargs):
@@ -36,5 +38,42 @@ class ParserArgMutuallyExclusiveType():
 def ArgGroupsDecorator(*args):
     def wrapper(func):
         func._arg_groups=args
+        return func
+    return wrapper
+
+def ActionArguement(*args, **kwargs):
+    #inspiration for action command decorator https://stackoverflow.com/questions/8632354/python-argparse-custom-actions-with-additional-arguments-passed
+
+    def wrapper(func):
+        def make_action(*original_args,**kwargs):
+            class PyconvCliCustomAction(argparse.Action):
+                def __call__(self, parser, args, values, option_string=None):
+                    # I run some inspection here so the user can have a little more freedom with
+                    # their method signature if they want to without having to go to all *args and **kwargs
+                    inspected_args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations  = inspect.getfullargspec(func)
+                    if varkw==None and varargs==None and len(inspected_args)==1 and inspected_args[0]=='self':
+                        func(self)
+                    elif varkw==None:
+                        params = pick(merge(kwargs,vars(args)),list(inspect.signature(func).parameters.keys()))
+                        if func.__name__ in params:
+                            params[func.__name__]=values
+                        func(self,*original_args,**params)
+                    else:
+                        params = merge(kwargs,vars(args))
+                        if func.__name__ in params:
+                            params[func.__name__]=values
+                        func(self,*original_args,**params)
+
+
+            return PyconvCliCustomAction
+        if 'action_param_nargs' in kwargs:
+            func._action_param_nargs=kwargs['action_param_nargs']
+            passed_kwargs=omit(kwargs,'action_param_nargs')
+        else:
+            func._action_param_nargs=0
+            passed_kwargs=kwargs
+        func._action_param_action=make_action
+        func._action_param_args=args
+        func._action_param_kwargs=passed_kwargs
         return func
     return wrapper

--- a/pyconvcli_internal_cli/utils/utils.py
+++ b/pyconvcli_internal_cli/utils/utils.py
@@ -1,8 +1,9 @@
 import pkg_resources
+from pyconvcli import ActionArguement
 class Utility_CLI():
     _cli_path=[]
+    @ActionArguement()
     def version(self):
         print(pkg_resources.get_distribution("pyconvcli").version)
-    def smile(self):
-        print(":)")
+
 

--- a/test_pyconvcli_internal_cli/test_pyconvcli.py
+++ b/test_pyconvcli_internal_cli/test_pyconvcli.py
@@ -4,6 +4,8 @@ import os
 import sys
 from contextlib import redirect_stdout
 from io import StringIO
+import pkg_resources
+from argparse import ArgumentError
 
 
 class TestPyConvCli(unittest.TestCase):
@@ -35,9 +37,90 @@ class TestPyConvCli(unittest.TestCase):
             cli.run()
         self.assertEqual(std_out.getvalue().strip(),"feature:False,notfeature:True")
 
-    # def test_app(self):
-    #     sys.argv = ['test_pyconvcli_internal_cli', "here", 'custom', 'route']
-    #     cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
-    #     args, parsers = cli.parse_args()
-    #     cli.parsers = parsers
-    #     cli.visualize()
+    def test_already_existing_path_as_callable(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "here", "testing", '--ascii', '<()()()>']
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),"ascii: '<()()()>'")
+
+    def test_already_existing_at_root_path_as_callable(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "here", '--ascii', '<()()()>']
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),"ascii: '<()()()>'")
+
+    def test_already_existing_at_root_path_as_callable(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "there"]
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),'no params but I was called')
+
+    def test_action_command(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "--version"]
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),pkg_resources.get_distribution("pyconvcli").version)
+
+    def test_2_narg_action_command(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargs2test",'3','resd']
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),str(['3', 'resd']))
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargs2test",'3','resd','greens']
+        with self.assertRaises(SystemExit):
+            cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+            cli.run()
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargs2test",'hello']
+        with self.assertRaises(SystemExit):
+            cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+            cli.run()
+
+    def test_star_narg_action_command(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargsstartest",'3','resd']
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out = StringIO()
+        with redirect_stdout(std_out):
+            cli.run()
+        self.assertEqual(std_out.getvalue().strip(),str(['3', 'resd']))
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargsstartest",'3','resd','greens']
+
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out2 = StringIO()
+
+        with redirect_stdout(std_out2):
+            cli.run()
+        self.assertEqual(std_out2.getvalue().strip(),str(['3', 'resd', 'greens']))
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargsstartest",'hello']
+
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out3 = StringIO()
+        with redirect_stdout(std_out3):
+            cli.run()
+        self.assertEqual(std_out3.getvalue().strip(),str(['hello']))
+
+        sys.argv = ['test_pyconvcli_internal_cli', "--nargsstartest",'hello', 'there']
+
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        std_out3 = StringIO()
+        with redirect_stdout(std_out3):
+            cli.run()
+        # just testing or demonstrating that with * as nargs we can't enter other sub commands
+        self.assertEqual(std_out3.getvalue().strip(),str(['hello', 'there']))
+
+
+    def test_app(self):
+        sys.argv = ['test_pyconvcli_internal_cli', "here", 'custom', 'route']
+        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+        args, parsers = cli.parse_args()
+        cli.parsers = parsers
+        cli.visualize()

--- a/test_pyconvcli_internal_cli/test_pyconvcli.py
+++ b/test_pyconvcli_internal_cli/test_pyconvcli.py
@@ -118,9 +118,9 @@ class TestPyConvCli(unittest.TestCase):
         self.assertEqual(std_out3.getvalue().strip(),str(['hello', 'there']))
 
 
-    def test_app(self):
-        sys.argv = ['test_pyconvcli_internal_cli', "here", 'custom', 'route']
-        cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
-        args, parsers = cli.parse_args()
-        cli.parsers = parsers
-        cli.visualize()
+    # def test_app(self):
+    #     sys.argv = ['test_pyconvcli_internal_cli', "here", 'custom', 'route']
+    #     cli = PyConvCli('test_pyconvcli_internal_cli', os.path.dirname(os.path.realpath(__file__)),'pyconvcli-test')
+    #     args, parsers = cli.parse_args()
+    #     cli.parsers = parsers
+    #     cli.visualize()

--- a/test_pyconvcli_internal_cli/test_resources/cli_class.py
+++ b/test_pyconvcli_internal_cli/test_resources/cli_class.py
@@ -1,5 +1,6 @@
-from pyconvcli import ParserArgGroupType, ParserArgMutuallyExclusiveType, ParserArgType, ArgGroupsDecorator
+from pyconvcli import ParserArgGroupType, ParserArgMutuallyExclusiveType, ParserArgType, ArgGroupsDecorator, ActionArguement
 import argparse
+import pkg_resources
 
 class Please_CLI():
     _cli_path=['here','custom','route']
@@ -47,3 +48,32 @@ class Exploritory_CLI():
 
     def filesN2OpenWidget(self, file:ParserArgType(type=argparse.FileType('r', encoding='UTF-8'), nargs=2)):
         print(f'file {file}')
+
+class repeated_CLI():
+    _cli_path=['here']
+    def testing(self, ascii:ParserArgType(type=ascii)):
+        print(f'ascii: {ascii}')
+
+class repeated_at_root_level_CLI():
+    _cli_path=[]
+    def here(self, ascii:ParserArgType(type=ascii)):
+        print(f'ascii: {ascii}')
+
+    def there(self):
+        print('no params but I was called')
+
+    @ActionArguement('testing','args',color='green')
+    def version(self,a,b,color=None):
+        print(pkg_resources.get_distribution("pyconvcli").version)
+
+    @ActionArguement('testing','args',color='green' )
+    def other(self,a,b,color=None):
+        print(a,b,color)
+
+    @ActionArguement(action_param_nargs=2)
+    def nargs2test(self, nargs2test=None):
+        print(nargs2test)
+
+    @ActionArguement(action_param_nargs='*')
+    def nargsstartest(self, nargsstartest=None):
+        print(nargsstartest)


### PR DESCRIPTION
added support for being able to define actions to a parser similar to the -help action. Adding support for this made the app more robust as you can now select the root again after moving from it. I also added warnings and made it safer so they don't accidentally run actions when copying the values from the app. That does mean that they don't get validation when copying while using actions in the app but it's better than them unintentionally running actions when just trying to copy the statement